### PR TITLE
Fix installation problem due to set[str] instead of typing.Set[str]

### DIFF
--- a/english_words/__init__.py
+++ b/english_words/__init__.py
@@ -13,7 +13,7 @@ from english_words.util import get_data_file_path
 
 def get_english_words_set(
     sources: typing.Iterable[str], alpha: bool = False, lower: bool = False
-) -> set[str]:
+) -> typing.Set[str]:
     # Set up a list to dump all the sets in
     sets_list = []
 


### PR DESCRIPTION
During installation, getting

      TypeError: 'type' object is not subscriptable

This will fix it.