### PR TITLE
Feature/support zipapps

### DIFF
--- a/english_words/__init__.py
+++ b/english_words/__init__.py
@@ -5,9 +5,9 @@ function.
 """
 
 from collections.abc import Iterable
-import os
+from importlib import resources
 import pickle
-from english_words.constants import PROCESSED_DATA_DIR, ALPHA, LOWER
+from english_words.constants import ALPHA, LOWER
 from english_words.util import get_data_file_path
 
 
@@ -36,8 +36,8 @@ def get_english_words_set(
         data_path = get_data_file_path(source, options)
 
         try:
-            with open(data_path, "rb") as f:
-                sets_list.append(pickle.load(f))
+            pickle_bytes = resources.read_binary(__package__, data_path)
+            sets_list.append(pickle.loads(pickle_bytes))
         except FileNotFoundError as e:
             raise ValueError(
                 f"{source} is not a valid word list identifier"

--- a/english_words/__init__.py
+++ b/english_words/__init__.py
@@ -36,7 +36,7 @@ def get_english_words_set(
         data_path = get_data_file_path(source, options)
 
         try:
-            pickle_bytes = resources.read_binary(__package__, data_path)
+            pickle_bytes = resources.files(__package__).joinpath("data/" + data_path).read_bytes()
             sets_list.append(pickle.loads(pickle_bytes))
         except FileNotFoundError as e:
             raise ValueError(

--- a/english_words/constants.py
+++ b/english_words/constants.py
@@ -5,7 +5,6 @@ import os
 
 # Directories
 PACKAGE_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-PROCESSED_DATA_DIR = "data"
 
 # Option constants
 ALPHA = "alpha"

--- a/english_words/constants.py
+++ b/english_words/constants.py
@@ -5,7 +5,7 @@ import os
 
 # Directories
 PACKAGE_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-PROCESSED_DATA_DIR = os.path.join(PACKAGE_BASE_DIR, "data")
+PROCESSED_DATA_DIR = "data"
 
 # Option constants
 ALPHA = "alpha"

--- a/english_words/util.py
+++ b/english_words/util.py
@@ -1,7 +1,6 @@
 """Stores utility functions for the main function."""
 
 from collections.abc import Iterable
-import os
 from english_words.constants import PROCESSED_DATA_DIR
 
 
@@ -15,6 +14,6 @@ def get_data_file_path(identifier: str, options: Iterable[str]) -> str:
         + ".pickle"
     )
 
-    data_file_path = os.path.join(PROCESSED_DATA_DIR, data_file_name)
+    data_file_path = PROCESSED_DATA_DIR + "/" + data_file_name
 
     return data_file_path

--- a/english_words/util.py
+++ b/english_words/util.py
@@ -1,7 +1,6 @@
 """Stores utility functions for the main function."""
 
 from collections.abc import Iterable
-from english_words.constants import PROCESSED_DATA_DIR
 
 
 def get_data_file_path(identifier: str, options: Iterable[str]) -> str:
@@ -13,7 +12,4 @@ def get_data_file_path(identifier: str, options: Iterable[str]) -> str:
         + "_".join(options)
         + ".pickle"
     )
-
-    data_file_path = PROCESSED_DATA_DIR + "/" + data_file_name
-
-    return data_file_path
+    return data_file_name


### PR DESCRIPTION
Existing implementation runs into IO errors when running inside of a zipapp so use importlib to read pickles.

I had a more elegant implementation, this version works with Python 3.9.